### PR TITLE
fix: handle SDPA attention implementation for vision encoder

### DIFF
--- a/aria/model/configuration_aria.py
+++ b/aria/model/configuration_aria.py
@@ -17,11 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
+
 from transformers.configuration_utils import PretrainedConfig
 
 from .moe_lm import AriaMoELMConfig
 from .vision_encoder import AriaVisionConfig
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,9 @@ class AriaConfig(PretrainedConfig):
             if attn_implementation is None:
                 vision_attn_implementation = "flash_attention_2"
             elif attn_implementation == "sdpa":
-                logger.warning("SDPA is not supported for vit, using flash_attention_2 instead")
+                logger.warning(
+                    "SDPA is not supported for vit, using flash_attention_2 instead"
+                )
                 vision_attn_implementation = "flash_attention_2"
             else:
                 vision_attn_implementation = attn_implementation

--- a/aria/model/configuration_aria.py
+++ b/aria/model/configuration_aria.py
@@ -21,6 +21,9 @@ from transformers.configuration_utils import PretrainedConfig
 
 from .moe_lm import AriaMoELMConfig
 from .vision_encoder import AriaVisionConfig
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # adapted from transformers.models.llava.configuration_llava.LlavaConfig
@@ -79,11 +82,13 @@ class AriaConfig(PretrainedConfig):
 
         if isinstance(vision_config, dict) and "model_type" in vision_config:
             vision_config = AriaVisionConfig(**vision_config)
-            vision_attn_implementation = (
-                "flash_attention_2"
-                if attn_implementation is None
-                else attn_implementation
-            )
+            if attn_implementation is None:
+                vision_attn_implementation = "flash_attention_2"
+            elif attn_implementation == "sdpa":
+                logger.warning("SDPA is not supported for vit, using flash_attention_2 instead")
+                vision_attn_implementation = "flash_attention_2"
+            else:
+                vision_attn_implementation = attn_implementation
             vision_config._attn_implementation = vision_attn_implementation
 
         self.vision_config = vision_config


### PR DESCRIPTION
ref: #54 

`AutoModelForCausalLM.from_pretrained(model_id_or_path, device_map="auto", torch_dtype=torch.bfloat16, trust_remote_code=True, attn_implementation="sdpa")` currently raises an error because our ViT model does not support the `sdpa` attention implementation. This PR introduces a fallback mechanism: when `attn_implementation="sdpa"` is set, the ViT model will automatically use `"flash_attention_2"` instead, while the language model continues to use `sdpa`. A warning will be issued to inform the user of this fallback behavior.
