### PR TITLE
apply z-loss and aux-loss only during training

### DIFF
--- a/aria/model/moe_lm.py
+++ b/aria/model/moe_lm.py
@@ -255,7 +255,8 @@ class TopKRouter(nn.Module):
                 - top_indices: Indices of top-k experts for each token.
                 - tokens_per_expert: Number of tokens assigned to each expert.
         """
-        logits = self.apply_z_loss(logits)
+        if self.training:
+            logits = self.apply_z_loss(logits)
 
         top_logits, top_indices = torch.topk(logits, k=self.config.moe_topk, dim=1)
         scores = torch.softmax(top_logits, dim=-1, dtype=torch.float32).type_as(logits)
@@ -267,7 +268,8 @@ class TopKRouter(nn.Module):
             max=self.config.moe_num_experts - 1,
         )
 
-        scores = self.apply_aux_loss(logits, tokens_per_expert, scores)
+        if self.training:
+            scores = self.apply_aux_loss(logits, tokens_per_expert, scores)
         return scores, top_indices, tokens_per_expert
 
     def forward(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bd45feaf-22ed-4d21-8805-7f49fab4e31b)
After profiling, I discovered that the routing logic consumes a significant amount of time, primarily due to `apply_z_loss` and `apply_aux_loss`, which are unnecessary during inference´. Thus, we can eliminate these operations in the inference phase